### PR TITLE
Fix broken behavior with extraction on Linux via mono

### DIFF
--- a/Archive.cs
+++ b/Archive.cs
@@ -1,6 +1,7 @@
 ﻿using Gibbed.IO;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using UnPSARC.Helpers;
 
 namespace UnPSARC
@@ -30,22 +31,22 @@ namespace UnPSARC
                 if (!Psarc.FileNames.ContainsKey(filenameHash))
                 {
                     Console.WriteLine("Archive Contains a hash which is not in filenames table: " + filenameHash);
-                    FileName = "_Unknowns\\" + filenameHash.Replace("-", "") + ".bin";
+                    FileName = "_Unknowns" + Path.DirectorySeparatorChar.ToString() + filenameHash.Replace("-", "") + ".bin";
                 }
                 else
                 {
-                    FileName = Psarc.FileNames[filenameHash].Replace("/", "\\");
+                    FileName = Psarc.FileNames[filenameHash].Replace("/", Path.DirectorySeparatorChar.ToString());
                 }
 
 
-                if (FileName.StartsWith("\\"))
+                if (FileName.StartsWith(Path.DirectorySeparatorChar.ToString()))
                     FileName = FileName.Remove(0, 1);
 
                 try
                 {
                     TryUnpack(Psarc.Reader, out HugeMemoryStream FileWriter, Psarc.Entries[i], Psarc.ZSizes, Psarc.BlockSize, Psarc.CompressionType);
-                    IOHelper.CheckFolderExists(FileName, Folder);
-                    Stream fileHandle = File.Open(@"\\?\" + Path.Combine(Folder, FileName), FileMode.Create, FileAccess.Write);
+					IOHelper.CheckFolderExists(FileName, Folder);
+                    Stream fileHandle = File.Open(Path.Combine(Folder, FileName), FileMode.Create, FileAccess.Write);
                     FileWriter.CopyTo(fileHandle);
                     fileHandle.Close();
                     Console.WriteLine("[" + i + "] " + FileName + " Exported!");
@@ -65,7 +66,6 @@ namespace UnPSARC
             }
 
             Console.WriteLine($"Unpacking done! | {Psarc.FilesCount - FailedFiles} of {Psarc.FilesCount} Files Exported");
-
         }
 
         public static void TryUnpack(Stream Reader, out HugeMemoryStream Writer, TEntry ThisEntry, TZSize[] ZSizes, int BlockSize, string CompressionType)

--- a/Archive.cs
+++ b/Archive.cs
@@ -1,6 +1,7 @@
 ﻿using Gibbed.IO;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using UnPSARC.Helpers;
 
 namespace UnPSARC
@@ -45,7 +46,13 @@ namespace UnPSARC
                 {
                     TryUnpack(Psarc.Reader, out HugeMemoryStream FileWriter, Psarc.Entries[i], Psarc.ZSizes, Psarc.BlockSize, Psarc.CompressionType);
 					IOHelper.CheckFolderExists(FileName, Folder);
-                    Stream fileHandle = File.Open(Path.Combine(Folder, FileName), FileMode.Create, FileAccess.Write);
+                    Stream fileHandle;
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)){
+                    	fileHandle = File.Open(@"\\?\" + Path.Combine(Folder, FileName), FileMode.Create, FileAccess.Write);
+                    }
+                    else{
+                    	fileHandle = File.Open(Path.Combine(Folder, FileName), FileMode.Create, FileAccess.Write);
+                    }
                     FileWriter.CopyTo(fileHandle);
                     fileHandle.Close();
                     Console.WriteLine("[" + i + "] " + FileName + " Exported!");

--- a/Archive.cs
+++ b/Archive.cs
@@ -1,7 +1,6 @@
 ﻿using Gibbed.IO;
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using UnPSARC.Helpers;
 
 namespace UnPSARC

--- a/Helpers/IOHelper.cs
+++ b/Helpers/IOHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Gibbed.IO;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Xml.Linq;
 
 namespace UnPSARC
@@ -55,10 +56,21 @@ namespace UnPSARC
         }
         public static void CheckFolderExists(string filename, string basefolder)
         {
-            if (!Directory.Exists(Path.GetDirectoryName(Path.Combine(basefolder, filename))))
-            {
-                Directory.CreateDirectory(Path.GetDirectoryName(Path.Combine(basefolder, filename)));
-            }
+        	if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        	{
+        		if (!Directory.Exists(Path.GetDirectoryName(@"\\?\" + Path.Combine(basefolder, filename))))
+        		{
+        			Directory.CreateDirectory(Path.GetDirectoryName(@"\\?\" + Path.Combine(basefolder, filename)));
+  	        	}
+        	}
+        	else
+        	{
+        		if (!Directory.Exists(Path.GetDirectoryName(Path.Combine(basefolder, filename))))
+        	    {
+        	    	Directory.CreateDirectory(Path.GetDirectoryName(Path.Combine(basefolder, filename)));
+        	  	}
+        	}
+            
         }
     }
 }

--- a/Helpers/IOHelper.cs
+++ b/Helpers/IOHelper.cs
@@ -55,9 +55,9 @@ namespace UnPSARC
         }
         public static void CheckFolderExists(string filename, string basefolder)
         {
-            if (!Directory.Exists(Path.GetDirectoryName(@"\\?\" + Path.Combine(basefolder, filename))))
+            if (!Directory.Exists(Path.GetDirectoryName(Path.Combine(basefolder, filename))))
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(@"\\?\" + Path.Combine(basefolder, filename)));
+                Directory.CreateDirectory(Path.GetDirectoryName(Path.Combine(basefolder, filename)));
             }
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -24,7 +24,7 @@ namespace UnPSARC
         {
             string currentApplicationPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string currentApplicationDirectory = Path.GetDirectoryName(currentApplicationPath);
-            string oodleLocation = currentApplicationDirectory + "\\oo2core_9_win64.dll";
+            string oodleLocation = Path.Combine(currentApplicationDirectory + "oo2core_9_win64.dll");
 
             return File.Exists(oodleLocation);
         }
@@ -67,7 +67,8 @@ namespace UnPSARC
                     {
                         string TempDir = Path.GetDirectoryName(args[0]);
                         if (TempDir == "") TempDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-                        string customOutputDirectory = TempDir + "\\" + Path.GetFileNameWithoutExtension(args[0]) + "_Unpacked";
+                        string customOutputDirectory = Path.GetFileNameWithoutExtension(args[0]) + "_Unpacked";
+                        // string customOutputDirectory = Path.GetFileNameWithoutExtension(args[0]); // Extract to same folder instead
                         if (Directory.Exists(customOutputDirectory) == false)
                             Directory.CreateDirectory(customOutputDirectory);
                         UnpackArchiveFile(args[0], customOutputDirectory);
@@ -89,7 +90,7 @@ namespace UnPSARC
                 {
                     if (!CommendHelper.IsFullPath(outputName))
                     {
-                        if (outputName.StartsWith("\\")) outputName = outputName.Remove(0, 1);
+                        if (outputName.StartsWith(Path.DirectorySeparatorChar.ToString())) outputName = outputName.Remove(0, 1);
                         outputName = Path.Combine(Environment.CurrentDirectory, outputName);
                     }
                     Console.WriteLine($"Packing {args[0]} to {outputName}");
@@ -154,7 +155,7 @@ namespace UnPSARC
             {
                 if (Path.GetFileName(fname) == "Filenames.txt")
                     continue;
-                string _ = fname.Replace(contentFolderPath + "\\", "").Replace("\\", "/");
+                string _ = fname.Replace(contentFolderPath + Path.DirectorySeparatorChar.ToString(), "").Replace(Path.DirectorySeparatorChar.ToString(), "/");
                 files.Add(_);
             }
             return string.Join("\n", files);


### PR DESCRIPTION
The excessive use of backslashes and other Windows specific IO oddities results in this program being functionally broken when run through mono on Linux, and probably macOS as well.

These fixes are mostly hacks involving `Path.DirectorySeparatorChar`, with a few proper `Path.Combine()`s as well. With these commits, you can extract psarc files on Linux. Creation is still broken, but that seems to be related to r.exe being unable to run, and I don't really need that functionality, as I'm just trying to get something working to implement in my Sonic the Fighters mod installer, HoneyPatcher. 

It isn't a *complete* fix in that regard, but I wanted to share these with upstream regardless.