### PR TITLE
Fix: Correct Path.Combine usage for Oodle DLL check

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -24,7 +24,7 @@ namespace UnPSARC
         {
             string currentApplicationPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string currentApplicationDirectory = Path.GetDirectoryName(currentApplicationPath);
-            string oodleLocation = Path.Combine(currentApplicationDirectory + "oo2core_9_win64.dll");
+            string oodleLocation = Path.Combine(currentApplicationDirectory, "oo2core_9_win64.dll");
 
             return File.Exists(oodleLocation);
         }


### PR DESCRIPTION
This PR fixes a bug in the CheckForOodle method where oo2core_9_win64.dll might not be found even if present in the application directory.

Problem:
The directory path and filename were concatenated using + before being passed as a single argument to Path.Combine. This prevented Path.Combine from adding the necessary directory separator (e.g., \).